### PR TITLE
Correct name of dvh notebook

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,7 +18,7 @@ PlatiPy documentation
     :hidden:
 
     _examples/visualise
-    _examples/dose_analysis
+    _examples/dvh_analysis
     
 .. toctree::
     :caption: Reference


### PR DESCRIPTION
I had the wrong name of the jupyter notebook to link it in the docs... I will just go ahead and merge this through...