### PR TITLE
Change merge to concat for contour comparison

### DIFF
--- a/platipy/imaging/visualisation/comparison.py
+++ b/platipy/imaging/visualisation/comparison.py
@@ -48,7 +48,7 @@ def contour_comparison(
     subsubtitle="",
     contour_cmap=plt.cm.get_cmap("rainbow"),
     structure_name_dict=None,
-    img_vis_kw={},
+    img_vis_kw=None,
 ):
     """Generates a custom figure for comparing two sets of contours (delineations) on an image.
 
@@ -86,6 +86,9 @@ def contour_comparison(
     # If no contour names are seleted we just use those which both contour_dicts have
     if s_select is None:
         s_select = [i for i in contour_dict_a.keys() if i in contour_dict_b.keys()]
+
+    if img_vis_kw is None:
+        img_vis_kw = {}
 
     if "cut" not in img_vis_kw:
 

--- a/platipy/imaging/visualisation/comparison.py
+++ b/platipy/imaging/visualisation/comparison.py
@@ -202,17 +202,15 @@ def contour_comparison(
         )
 
         # compute metrics and add to dataframe
-        df_metrics = df_metrics.append(
-            {
+        row = pd.DataFrame([{
                 "STRUCTURE": s,
                 "DSC": dsc,
                 "MDA_mm": mda,
                 "HD_mm": hd,
                 "VOL_A_cm3": vol_a,
                 "VOL_B_cm3": vol_b,
-            },
-            ignore_index=True,
-        )
+        }])
+        df_metrics = pd.concat([df_metrics, row])
 
     # If there are no labels we can make the table bigger
     if title == "" and subsubtitle == "" and subsubtitle == "":

--- a/requirements-backend.txt
+++ b/requirements-backend.txt
@@ -5,3 +5,4 @@ celery >= 5.2.3
 redis >= 3.5.3
 psutil >= 5.8.0
 gunicorn >= 20.0.4
+Jinja2 < 3.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,3 +13,4 @@ nbstripout == 0.3.9
 furo == 2021.4.11b34
 nbsphinx == 0.8.5
 m2r2 == 0.2.7
+Jinja2 < 3.1


### PR DESCRIPTION
Hi @rnfinnegan,

pandas are deprecating `merge` so these will need to be changed over to `concat`. Ive done that for the contour comparison function (since that is the one I am using and it was spitting out a heap of warnings). But there might be a few other places where we need to change it. We should probably change it in those places too before merging this through?