### PR TITLE
use standard list rather than numpy for dilation kernel

### DIFF
--- a/platipy/imaging/label/comparison.py
+++ b/platipy/imaging/label/comparison.py
@@ -358,7 +358,7 @@ def compute_apl(label_ref, label_test, distance_threshold_mm=3):
 
         if (
             sitk.GetArrayViewFromImage(label_ref)[i].sum()
-            + sitk.GetArrayViewFromImage(label_ref)[i].sum()
+            + sitk.GetArrayViewFromImage(label_test)[i].sum()
         ) == 0:
             continue
 

--- a/platipy/imaging/label/comparison.py
+++ b/platipy/imaging/label/comparison.py
@@ -366,7 +366,8 @@ def compute_apl(label_ref, label_test, distance_threshold_mm=3):
         label_test_contour = sitk.LabelContour(label_test[:, :, i])
 
         if distance_threshold_mm > 0:
-            label_ref_contour = sitk.BinaryDilate(label_ref_contour, np.repeat(distance, 2))
+            kernel = [int(distance) for k in range(2)]
+            label_ref_contour = sitk.BinaryDilate(label_ref_contour, kernel)
 
         # mask out the locations in agreement
         added_path = sitk.MaskNegated(label_test_contour, label_ref_contour)


### PR DESCRIPTION
Hi @rnfinnegan, not sure why but my environment/simpleitk version didn't like using the numpy array as a kernel for the binarydilate function in the APL function. This should hopefully work across versions.