### PR TITLE
Duplicate code in rtstruct_to_nifti removed

### DIFF
--- a/platipy/dicom/io/rtstruct_to_nifti.py
+++ b/platipy/dicom/io/rtstruct_to_nifti.py
@@ -149,10 +149,6 @@ def transform_point_set_from_dicom_struct(dicom_image, dicom_struct, spacing_ove
             logger.debug("Contour sequence empty for this structure, skipping.")
             continue
 
-        if len(struct_point_sequence[struct_index].ContourSequence) == 0:
-            logger.debug("Contour sequence empty for this structure, skipping.")
-            continue
-
         if (
             not struct_point_sequence[struct_index].ContourSequence[0].ContourGeometricType
             == "CLOSED_PLANAR"


### PR DESCRIPTION
Hi,
I'm currently working on a project involving importing dicom rt structures and I found this `if` condition defined twice in your code:
```
if len(struct_point_sequence[struct_index].ContourSequence) == 0:
    logger.debug("Contour sequence empty for this structure, skipping.")
    continue
```