### PR TITLE
Bug fix for crop code

### DIFF
--- a/platipy/imaging/utils/crop.py
+++ b/platipy/imaging/utils/crop.py
@@ -46,7 +46,7 @@ def label_to_roi(label, expansion_mm=[0, 0, 0], return_as_list=False):
     bounding_box = np.array(label_stats_image_filter.GetBoundingBox(1))
 
     index = [bounding_box[x * 2] for x in range(3)]
-    size = [bounding_box[(x * 2) + 1] - bounding_box[x * 2] for x in range(3)]
+    size = [bounding_box[(x * 2) + 1] - bounding_box[x * 2] + 1 for x in range(3)]
 
     expansion_mm = np.array(expansion_mm)
     expansion = (expansion_mm / image_spacing).astype(int)


### PR DESCRIPTION
Hi @rnfinnegan,

I just came across and issue where I was getting a different value for when running the `compute_metric_dsc` function with and without the `auto_crop`. This led me down to tracking down this issue. I think the size of the crop box needs to be increased by 1 (as fixed here). Please accept and merge if you agree :)