### PR TITLE
Replace np.product with np.prod pending deprecation

### DIFF
--- a/platipy/imaging/dose/dvh.py
+++ b/platipy/imaging/dose/dvh.py
@@ -87,7 +87,7 @@ def calculate_dvh_for_labels(dose_grid, labels, bin_width=0.1, max_dose=None):
         mask_array = sitk.GetArrayFromImage(mask)
 
         # Compute cubic centimetre volume of structure
-        cc = mask_array.sum() * np.product([a / 10 for a in mask.GetSpacing()])
+        cc = mask_array.sum() * np.prod([a / 10 for a in mask.GetSpacing()])
 
         bins, values = calculate_dvh(
             dose_grid, labels[k], bins=np.arange(-bin_width / 2, max_dose + bin_width, bin_width)

--- a/platipy/imaging/dose/metric.py
+++ b/platipy/imaging/dose/metric.py
@@ -72,7 +72,7 @@ def calculate_d_to_volume(dose_grid, label, volume, volume_in_cc=False):
     mask_array = sitk.GetArrayFromImage(label)
 
     if volume_in_cc:
-        volume = (volume * 1000 / ((mask_array > 0).sum() * np.product(label.GetSpacing()))) * 100
+        volume = (volume * 1000 / ((mask_array > 0).sum() * np.prod(label.GetSpacing()))) * 100
 
     if volume > 100:
         volume = 100
@@ -106,7 +106,7 @@ def calculate_v_receiving_dose(dose_grid, label, dose_threshold, relative=True):
     if relative:
         return relative_volume
 
-    total_volume = (mask_array > 0).sum() * np.product(label.GetSpacing()) / 1000
+    total_volume = (mask_array > 0).sum() * np.prod(label.GetSpacing()) / 1000
 
     return relative_volume * total_volume
 

--- a/platipy/imaging/label/comparison.py
+++ b/platipy/imaging/label/comparison.py
@@ -29,7 +29,7 @@ def compute_volume(label):
         float: The volume (in cubic centimetres)
     """
 
-    return sitk.GetArrayFromImage(label).sum() * np.product(label.GetSpacing()) / 1000
+    return sitk.GetArrayFromImage(label).sum() * np.prod(label.GetSpacing()) / 1000
 
 
 def compute_surface_dsc(label_a, label_b, tau=3.0):
@@ -159,7 +159,7 @@ def compute_volume_metrics(label_a, label_b):
     arr_intersection = arr_a & arr_b
     arr_union = arr_a | arr_b
 
-    voxel_volume = np.product(label_a.GetSpacing()) / 1000.0  # Conversion to cm^3
+    voxel_volume = np.prod(label_a.GetSpacing()) / 1000.0  # Conversion to cm^3
 
     # 2|A & B|/(|A|+|B|)
     dsc = (2.0 * arr_intersection.sum()) / (arr_a.sum() + arr_b.sum())

--- a/platipy/imaging/label/fusion.py
+++ b/platipy/imaging/label/fusion.py
@@ -109,7 +109,7 @@ def compute_weight_map(
         view_mask = view_as_windows(arr_mask, window_box_im)
 
         # Flatten to have a list of patches (that are also flattened)
-        new_shape = (np.product(view_target.shape[:3]), np.product(view_target.shape[3:]))
+        new_shape = (np.prod(view_target.shape[:3]), np.prod(view_target.shape[3:]))
         view_target_flat = np.reshape(view_target, new_shape)
         view_moving_flat = np.reshape(view_moving, new_shape)
         view_mask_flat = np.reshape(view_mask, new_shape)

--- a/platipy/imaging/projects/cardiac/run.py
+++ b/platipy/imaging/projects/cardiac/run.py
@@ -567,7 +567,7 @@ def run_cardiac_segmentation(img, guide_structure=None, settings=CARDIAC_SETTING
         if crop_atlas_to_structures:
             logger.info("Automatically cropping atlas: %s", atlas_id)
 
-            original_volume = np.product(image.GetSize())
+            original_volume = np.prod(image.GetSize())
 
             crop_box_size, crop_box_index = label_to_roi(
                 structures.values(), expansion_mm=crop_atlas_expansion_mm
@@ -575,7 +575,7 @@ def run_cardiac_segmentation(img, guide_structure=None, settings=CARDIAC_SETTING
 
             image = crop_to_roi(image, size=crop_box_size, index=crop_box_index)
 
-            final_volume = np.product(image.GetSize())
+            final_volume = np.prod(image.GetSize())
 
             logger.info("  > Volume reduced by factor %.2f", original_volume / final_volume)
 
@@ -654,7 +654,7 @@ def run_cardiac_segmentation(img, guide_structure=None, settings=CARDIAC_SETTING
     logger.info("Calculated crop box:")
     logger.info("  > %s", crop_box_index)
     logger.info("  > %s", crop_box_size)
-    logger.info("  > Vol reduction = %.2f", np.product(img.GetSize()) / np.product(crop_box_size))
+    logger.info("  > Vol reduction = %.2f", np.prod(img.GetSize()) / np.prod(crop_box_size))
 
     """
     Step 2 - Rigid registration of target images

--- a/platipy/imaging/projects/multiatlas/run.py
+++ b/platipy/imaging/projects/multiatlas/run.py
@@ -167,7 +167,7 @@ def run_segmentation(img, settings=MUTLIATLAS_SETTINGS_DEFAULTS):
         if crop_atlas_to_structures:
             logger.info("Automatically cropping atlas: %s", atlas_id)
 
-            original_volume = np.product(image.GetSize())
+            original_volume = np.prod(image.GetSize())
 
             crop_box_size, crop_box_index = label_to_roi(
                 structures.values(), expansion_mm=crop_atlas_expansion_mm
@@ -175,7 +175,7 @@ def run_segmentation(img, settings=MUTLIATLAS_SETTINGS_DEFAULTS):
 
             image = crop_to_roi(image, size=crop_box_size, index=crop_box_index)
 
-            final_volume = np.product(image.GetSize())
+            final_volume = np.prod(image.GetSize())
 
             logger.info("  > Volume reduced by factor %.2f", original_volume/final_volume)
 
@@ -245,7 +245,7 @@ def run_segmentation(img, settings=MUTLIATLAS_SETTINGS_DEFAULTS):
     logger.info("Calculated crop box:")
     logger.info("  > %s", crop_box_index)
     logger.info("  > %s", crop_box_size)
-    logger.info("  > Vol reduction = %.2f", np.product(img.GetSize())/np.product(crop_box_size))
+    logger.info("  > Vol reduction = %.2f", np.prod(img.GetSize())/np.prod(crop_box_size))
 
     """
     Step 2 - Rigid registration of target images

--- a/platipy/imaging/utils/valve.py
+++ b/platipy/imaging/utils/valve.py
@@ -120,7 +120,7 @@ def generate_valve_using_cylinder(
         overlap = sitk.BinaryDilate(label_atrium, dilation_img) & sitk.BinaryDilate(
             label_ventricle, dilation_img
         )
-        overlap_vol = np.sum(sitk.GetArrayFromImage(overlap) * np.product(overlap.GetSpacing()))
+        overlap_vol = np.sum(sitk.GetArrayFromImage(overlap) * np.prod(overlap.GetSpacing()))
         dilation += 1
 
     # Now we can calculate the location of the valve

--- a/platipy/imaging/utils/ventricle.py
+++ b/platipy/imaging/utils/ventricle.py
@@ -65,7 +65,7 @@ def extract(
     segment_img.CopyInformation(template_img)
 
     # Make sure area exceeds lower bound
-    area = segment_arr.sum() * np.product(segment_img.GetSpacing())
+    area = segment_arr.sum() * np.prod(segment_img.GetSpacing())
     if area < min_area_mm2:
         segment_img *= 0
 
@@ -167,8 +167,8 @@ def generate_left_ventricle_segments(
 
     if verbose:
         print("Module 1: Cropping and initial alignment.")
-        vol_before = np.product(contours[label_heart].GetSize())
-        vol_after = np.product(working_contours[label_heart].GetSize())
+        vol_before = np.prod(contours[label_heart].GetSize())
+        vol_after = np.prod(working_contours[label_heart].GetSize())
         print(f"  Images cropped. Volume reduction: {vol_before/vol_after:.3f}")
 
     # Initially we should reorient based on the cardiac axis


### PR DESCRIPTION
First off, thanks for a very useful tool!

This PR should help future-proof for the release of Numpy 2.0 while not changing any actual behavior of platipy. Currently, while using the latest Numpy (1.25), I get deprecation messages like this:
```bash
C:\Users\<redacted>\AppData\Local\Temp\ipykernel_26204\2109769358.py:19: DeprecationWarning: `product` is deprecated as of NumPy 1.25.0, and will be removed in NumPy 2.0. Please use `prod` instead.
  leaky_dvh = calculate_dvh_for_labels(leaky_dose, dvh_structures)
```

Here is the relevant deprecation notice for Numpy 1.25:
https://numpy.org/devdocs/release/1.25.0-notes.html#deprecations

This change should not break compatibility with old versions, as `np.prod` has been a method since at least v1.10.1 (probably earlier), while platipy currently requires v1.10.2 as the minimum numpy version
https://docs.scipy.org/doc/numpy-1.10.1/reference/generated/numpy.prod.html#numpy.prod

Also this change should be purely cosmetic. In the numpy pull request to deprecate `np.product`, it is replaced seamlessly by `np.prod`
https://github.com/numpy/numpy/pull/23314/files