### PR TITLE
`get_cmap`, `center_of_mass` deprecation updates

### DIFF
--- a/platipy/imaging/label/utils.py
+++ b/platipy/imaging/label/utils.py
@@ -15,7 +15,7 @@
 import SimpleITK as sitk
 import numpy as np
 
-from scipy.ndimage.measurements import center_of_mass
+from scipy.ndimage import center_of_mass
 
 from platipy.imaging.utils.math import gen_primes
 

--- a/platipy/imaging/visualisation/visualiser.py
+++ b/platipy/imaging/visualisation/visualiser.py
@@ -1200,7 +1200,7 @@ class ImageVisualiser:
                 s_min = nda.min()
 
             colormap_name = scalar.colormap.name
-            colormap = plt.cm.get_cmap(colormap_name)
+            colormap = matplotlib.colormaps[colormap_name]
 
             if scalar.discrete_levels:
                 colormap = colormap.resampled(scalar.discrete_levels)
@@ -1209,7 +1209,7 @@ class ImageVisualiser:
                 if not scalar.discrete_levels:
                     scalar.discrete_levels = 10
 
-                colormap = plt.cm.get_cmap(colormap_name, scalar.discrete_levels)
+                colormap = matplotlib.colormaps[colormap_name]
                 contour_levels = scalar.discrete_levels
 
             if scalar.norm:


### PR DESCRIPTION
Hi @pchlap,

Just some updates to those 2 functions as they are popping up as warnings when using pylint and will be deprecated soon in future updates to those packages. Thanks!