### PR TITLE
Support holes in RTSTRUCT contours

### DIFF
--- a/platipy/dicom/io/crawl.py
+++ b/platipy/dicom/io/crawl.py
@@ -343,7 +343,7 @@ def transform_point_set_from_dicom_struct(image, dicom_struct, spacing_override=
                 xVertexArr_image, yVertexArr_image, shape=sliceArr.shape
             )
             sliceArr[filledIndicesX, filledIndicesY] = 1
-            image_blank[zIndex] += sliceArr.T
+            image_blank[zIndex] ^= sliceArr.T
 
         struct_image = sitk.GetImageFromArray(1 * (image_blank > 0))
         struct_image.CopyInformation(image)

--- a/platipy/dicom/io/rtstruct_to_nifti.py
+++ b/platipy/dicom/io/rtstruct_to_nifti.py
@@ -194,7 +194,7 @@ def transform_point_set_from_dicom_struct(dicom_image, dicom_struct, spacing_ove
             )
             slice_arr[filled_indices_y, filled_indices_x] = 1
 
-            image_blank[z_index] += slice_arr
+            image_blank[z_index] ^= slice_arr
 
         if not skip_contour:
             struct_image = sitk.GetImageFromArray(1 * (image_blank > 0))


### PR DESCRIPTION
Uses a XOR to combine masks generated from contours, this seems to provide the correct logic to support multiple contours on a single slice including a contour defining a hole within another contour.

This should resolve #244