### PR TITLE
Fix API_URL and remove unused endpoints

### DIFF
--- a/platipy/dicom/download/tcia.py
+++ b/platipy/dicom/download/tcia.py
@@ -27,16 +27,13 @@ from platipy.dicom.io.crawl import (
     process_dicom_directory,
 )
 
-API_URL = "https://services.cancerimagingarchive.net/services/v4/TCIA"
+API_URL = "https://services.cancerimagingarchive.net/nbia-api/services/v1"
 
-collection_endpoint = f"{API_URL}/query/getCollectionValues"
-modalities_endpoint = f"{API_URL}/query/getModalityValues"
-patient_endpoint = f"{API_URL}/query/getPatient"
-series_endpoint = f"{API_URL}/query/getSeries"
-series_size_endpoint = f"{API_URL}/query/getSeriesSize"
-download_series_endpoint = f"{API_URL}/query/getImage"
-sop_uids_endpoint = f"{API_URL}/query/getSOPInstanceUIDs"
-download_image_endpoint = f"{API_URL}/query/getSingleImage"
+collection_endpoint = f"{API_URL}/getCollectionValues"
+modalities_endpoint = f"{API_URL}/getModalityValues"
+patient_endpoint = f"{API_URL}/getPatient"
+series_endpoint = f"{API_URL}/getSeries"
+download_series_endpoint = f"{API_URL}/getImage"
 
 
 def get_collections():


### PR DESCRIPTION
I think this will fix downloads from TCIA so that you're getting the latest datasets via our newer API.  Once you confirm this works properly, feel free to close https://github.com/pyplati/platipy/issues/276 unless you prefer to do something more advanced at some point.  

Note that both what you had previously and this change will only support accessing fully public data that doesn't require logging in.  https://pypi.org/project/tcia-utils/ has functionality to take care of all the authentication stuff if you wanted to consider using that at some point, but it may be overkill if you're just trying to provide your users with easy access to sample data for testing your tool.