### PR TITLE
Skip zero slices when calculating apical

### DIFF
--- a/platipy/imaging/label/utils.py
+++ b/platipy/imaging/label/utils.py
@@ -79,7 +79,7 @@ def get_com(label, as_int=True, real_coords=False):
 
     else:
         if as_int:
-            com = [int(i) for i in com]
+            com = [int(i) if not np.isnan(i) else i for i in com]
 
     return com
 

--- a/platipy/imaging/utils/ventricle.py
+++ b/platipy/imaging/utils/ventricle.py
@@ -392,8 +392,13 @@ def generate_left_ventricle_segments(
     lv_com_apical_list = []
     rv_com_apical_list = []
     for n in range(inf_limit_lv, apical_extent):
-        lv_com_apical_list.append(get_com(working_contours[label_left_ventricle][:, :, n]))
-        rv_com_apical_list.append(get_com(working_contours[label_right_ventricle][:, :, n]))
+        lv_com = get_com(working_contours[label_left_ventricle][:, :, n])
+        if (not np.any(np.isnan(lv_com))):
+            lv_com_apical_list.append(lv_com)
+
+        rv_com = get_com(working_contours[label_right_ventricle][:, :, n])
+        if (not np.any(np.isnan(rv_com))):
+            rv_com_apical_list.append(get_com(working_contours[label_right_ventricle][:, :, n]))
 
     lv_com_apical = np.mean(lv_com_apical_list, axis=0)
     rv_com_apical = np.mean(rv_com_apical_list, axis=0)

--- a/platipy/imaging/utils/ventricle.py
+++ b/platipy/imaging/utils/ventricle.py
@@ -398,7 +398,7 @@ def generate_left_ventricle_segments(
 
         rv_com = get_com(working_contours[label_right_ventricle][:, :, n])
         if (not np.any(np.isnan(rv_com))):
-            rv_com_apical_list.append(get_com(working_contours[label_right_ventricle][:, :, n]))
+            rv_com_apical_list.append(rv_com)
 
     lv_com_apical = np.mean(lv_com_apical_list, axis=0)
     rv_com_apical = np.mean(rv_com_apical_list, axis=0)


### PR DESCRIPTION
Addresses the issue reported here: https://github.com/pyplati/platipy/issues/308

Seems like in rare caes the RV doesn't extend inferiorly above the LV which was causing this issue.